### PR TITLE
updated dependency to mariadb-client

### DIFF
--- a/container-build/web/Dockerfile
+++ b/container-build/web/Dockerfile
@@ -26,7 +26,7 @@
 FROM php:7.2-apache
 
 RUN apt-get update \
- && apt-get install -y vim git zlib1g-dev mysql-client libzip-dev \
+ && apt-get install -y vim git zlib1g-dev mariadb-client libzip-dev \
  && docker-php-ext-install zip mysqli pdo_mysql \
  && pecl install xdebug \
  && docker-php-ext-enable xdebug \


### PR DESCRIPTION
With the latest update to php 7.2 images, which use Debian, the previously used mysql-client is no longer available in repos by default. Therefore, switching to mariadb-client for ease of use.